### PR TITLE
Fix: Auto Clear Ghosts Not Working -(Caused by Non-ASCII Characters in HLSL Shader String)

### DIFF
--- a/GhostBusterPlus/Processor.cs
+++ b/GhostBusterPlus/Processor.cs
@@ -249,7 +249,7 @@ namespace ScreenRefreshApp
                             // Calculate the absolute difference
                             float diff = abs(oldPixel - newPixel);
                             
-                            // If the difference exceeds our threshold (0.05 ≈ 5% brightness change)
+                            // If the difference exceeds our threshold (0.05 is approximately 5% brightness change)
                             // count this pixel as changed
                             if (diff > 0.05)
                             {


### PR DESCRIPTION
  Hello, I downloaded the latest version of the program (v1.0.0), but the automatic residual image cleanup feature remains unavailable on my system (Windows 11 23H2), running on a ThinkBook Plus Gen 4. I am using the latest e-ink Plus (v1.0.124.3) and have configured the F4 key to clear residual images within the e-ink Plus settings. I'm uncertain if this issue is related to the specific .NET version.

  As I am not familiar with C# or .NET, I downloaded the source code and proceeded to debug it in Visual Studio, using AI to assist with the process. (The source code appeared to be missing a Logger.cs file, which I supplemented with AI to enable normal startup.)

During runtime, the application threw a compilation exception, with the following details:

**Exception Thrown**: "SharpDX.CompilationException" (Located in SharpDX.D3DCompiler.dll) 2025-11-12 16:56:03 - INFO: DirectX initialization failed: G:\myProject\GhostBusterPlus-main-origin\GhostBusterPlus\bin\Debug\unknown(44,21): **error X3000: syntax error: unexpected end of file**

Through further attempts with AI assistance, the root cause was finally identified: **a non-ASCII character within a comment in the HLSL-related shader code string in Processor.cs was causing the compilation failure**. This issue is reproducible with any non-ASCII character (e.g., Chinese characters).

Removing this problematic character from the code string resolved the issue, and the automatic residual image cleanup function is now working correctly.

------------------------------------------------------------------------ Minor Suggestion:

I also have a small suggestion: Could the program's default behavior of automatically switching to the e-ink theme upon first launch be changed to a non-default/opt-in setting? Thank you for your consideration.