### PR TITLE
Fix: Resolve Auto Clear Ghosts and context menu hang on initial launch (under 250% display scaling)

### DIFF
--- a/GhostBusterPlus/Processor.cs
+++ b/GhostBusterPlus/Processor.cs
@@ -117,10 +117,22 @@ namespace ScreenRefreshApp
                 outputDuplication = output1.DuplicateOutput(d3dDevice);
                 Logger.Log("Output duplication initialized.");
 
-                // Get the desktop dimensions to create appropriately sized textures
-                int width = output.Description.DesktopBounds.Right - output.Description.DesktopBounds.Left;
-                int height = output.Description.DesktopBounds.Bottom - output.Description.DesktopBounds.Top;
+                // Get the desktop dimensions from the duplication interface instead of output bounds
+                // This ensures we get the actual texture dimensions that will be captured
+                var duplicationDesc = outputDuplication.Description.ModeDescription;
+                int width = duplicationDesc.Width;
+                int height = duplicationDesc.Height;
                 Logger.Log($"Texture dimensions: Width={width}, Height={height}");
+                Logger.Log($"Output duplication format: {duplicationDesc.Format}");
+                Logger.Log($"Output duplication scaling: {duplicationDesc.Scaling}");
+
+                // Log additional DPI information for debugging
+                using (var graphics = System.Drawing.Graphics.FromHwnd(IntPtr.Zero))
+                {
+                    float dpiX = graphics.DpiX;
+                    float dpiY = graphics.DpiY;
+                    Logger.Log($"System DPI: X={dpiX}, Y={dpiY}");
+                }
 
                 // Create texture description for grayscale images
                 // Using R32_Float format for single-channel grayscale values (32-bit float per pixel)


### PR DESCRIPTION
Hello! This commit resolves an issue where the application would hang (freezing the context menu) and the Auto Clear Ghosts function would fail upon initial launch.

The Problem & Observation: **I use 250% display scaling on my PC**. After launching, the application continuously logged "Screenshot processing error: Texture dimensions mismatch - reinit needed". I suspected this might be related to DPI scaling, and the following fix indeed solved the problem.

The nature of the dimension mismatch was analyzed by Claude LLM, revealing the following:

output.Description.DesktopBounds returned the logical resolution (the virtual resolution after scaling).

However, the DirectX output capture returned the actual physical resolution.

The Fix: The core solution involves obtaining the correct dimensions by switching the source from output.Description.DesktopBounds to outputDuplication.Description.ModeDescription.

Additional Changes: To aid future diagnostics, I've also added enhanced logging for DPI, output format, and scaling information. Thank you!